### PR TITLE
$ sign typo and fixing functional errors

### DIFF
--- a/cogs/misc.py
+++ b/cogs/misc.py
@@ -335,7 +335,7 @@ class misc(commands.Cog):
             await ctx.channel.send("Lawda you're not authorised to do that")
 
 
-    @cog_ext.cog_slash( name="unmute",
+    @cog_ext.cog_slash(name="unmute",
                         description="Unmutes the user mentioned",
                         guild_ids=[GUILD_ID],
                         options=[
@@ -345,6 +345,7 @@ class misc(commands.Cog):
                                 option_type=6,
                                 required=True
                             )
+                        ]
                       )
     # @ commands.command(aliases=['unmute'])
     async def _unmute(self, ctx, User: discord.Member):
@@ -692,7 +693,7 @@ class misc(commands.Cog):
     #    else:
     #        await ctx.channel.send("Lawda you can't execute this command")
 
-"""
+    """
     @commands.command()
     async def scrape(self, ctx, rr:int = 0, ec:int = 0):
         if((self.admin in  ctx.author.roles) or (self.bot_devs in ctx.author.roles)):
@@ -722,7 +723,7 @@ class misc(commands.Cog):
             await ctx.send(ctx.author.mention)
         else:
             await ctx.send("You are not authorised for this command")
-"""
+    """
     # @commands.command(aliases=['restart'])
     @cog_ext.cog_slash( name="restart",
                         guild_ids=[GUILD_ID],

--- a/cogs/verification.py
+++ b/cogs/verification.py
@@ -210,7 +210,7 @@ class verification(commands.Cog):
                         await user.add_roles(camp_rl)
                     except Exception as e:
                         print(e)
-                        await ctx.channel.send(f"{user.mention} Looks like your role isn't on the server yet. DM or tag {self.admin.mentio$
+                        await ctx.channel.send(f"{user.mention} Looks like your role isn't on the server yet. DM or tag {self.admin.mention}")
                         return
                 elif dat[2] == 'Sem-2':
                     str_rl = stream(dat[6])
@@ -222,7 +222,7 @@ class verification(commands.Cog):
                         await user.add_roles(camp_rl)
                     except Exception as e:
                         print(e)
-                        await ctx.channel.send(f"{user.mention} Looks like your role isn't on the server yet. DM or tag {self.admin.mentio$
+                        await ctx.channel.send(f"{user.mention} Looks like your role isn't on the server yet. DM or tag {self.admin.mention}")
                         return
             else:
                 await ctx.channel.send(f"{user.mention}, now enter PRN to complete verification")


### PR DESCRIPTION
unclosed brackets and dollar sign typos
fixing slash command errors which did not allow functions to work (unmute command and restart bot)